### PR TITLE
Removed package a4

### DIFF
--- a/src/convert_to_tex.sh
+++ b/src/convert_to_tex.sh
@@ -11,7 +11,6 @@ cat > $DIR/main.tex <<EOF
 
 \usepackage{amsmath,amssymb,latexsym}
 \usepackage{algorithm, algorithmic}
-\usepackage{a4}
 \usepackage{graphicx}
 \usepackage{varioref}
 \usepackage{hyperref}


### PR DESCRIPTION
The package a4.sty as well as other LaTeX packages should not be used
in current documents (according to l2tabu
http://mirrors.ibiblio.org/CTAN/info/l2tabu/english/l2tabuen.pdf).
