### PR TITLE
Using scrbook instead of book

### DIFF
--- a/src/convert_to_tex.sh
+++ b/src/convert_to_tex.sh
@@ -7,7 +7,7 @@ fi
 mkdir $DIR
 
 cat > $DIR/main.tex <<EOF
-\documentclass[oribibl,a4paper]{book}
+\documentclass[oribibl]{scrbook}
 
 \usepackage{amsmath,amssymb,latexsym}
 \usepackage{algorithm, algorithmic}


### PR DESCRIPTION
I would suggest using the document class scrbook.
This is part of KOMAScript 
(http://www.ctan.org/tex-archive/macros/latex/contrib/koma-script/scrguien.pdf/)
and uses some reasonable default settings for documents. It uses A4 by
default, so the option is not needed anymore.
