### PR TITLE
Inserted package for LaTeX font encodings

### DIFF
--- a/src/convert_to_tex.sh
+++ b/src/convert_to_tex.sh
@@ -16,6 +16,7 @@ fi
 cat > $DIR/main.tex <<EOF
 \documentclass[oribibl]{scrbook}
 
+\usepackage[T1]{fontenc}
 \usepackage{amsmath,amssymb,latexsym}
 \usepackage{algorithm, algorithmic}
 \usepackage{graphicx}


### PR DESCRIPTION
The package fontenc with T1-encoding is generally usefull when some wants to copy parts of PDF (esp. when there are strange glyphs). Font in general look nicer.
