### PR TITLE
LaTeX: Use tocloft to avoid ugliness in the TOC

### DIFF
--- a/src/convert_to_tex.sh
+++ b/src/convert_to_tex.sh
@@ -26,11 +26,13 @@ cat > $DIR/main.tex <<EOF
 \usepackage{eurosym}
 \usepackage{placeins}
 \usepackage{pdfpages}
+\usepackage{tocloft}
 
 \let\stdsection\section
 \renewcommand*{\section}{\FloatBarrier\stdsection}
 \let\stdsubsection\subsection
 \renewcommand*{\subsection}{\FloatBarrier\stdsubsection}
+\renewcommand{\cftsubsecnumwidth}{3.8em}
 
 
 \begin{document}


### PR DESCRIPTION
There was a layout issue where the subsection number would run into
the subsection header in the TOC, due to the number running into
triple digits. Fixed by using the package tocloft to make the
bounding box bigger.
