### PR TITLE
Title, author, language and license in epub metadata

### DIFF
--- a/src/convert_to_epub.sh
+++ b/src/convert_to_epub.sh
@@ -10,7 +10,7 @@ for f in `find .. -name "*.jpg"`; do ln -s $f . ; done
 for f in `find .. -name "*.png"`; do ln -s $f . ; done
 
 #do the conversion
-pandoc --epub-cover-image=../cover-800.jpg book.md -o book.epub
+pandoc --epub-cover-image=../cover-800.jpg --epub-metadata=../metadata.xml book.md -o book.epub
 
 # Only set if not overriden by an environment variable
 DATE=${DATE:-`date +%F`}

--- a/src/metadata.xml
+++ b/src/metadata.xml
@@ -1,0 +1,4 @@
+<dc:title>The CryptoParty Handbook</dc:title>
+<dc:creator>The Cryptoparty Community</dc:creator>
+<dc:language>en-US</dc:language>
+<dc:rights>Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)</dc:rights>


### PR DESCRIPTION
This pull request adds title, author, language and license information in the metadata file of the epub. This makes it possible for various applications and services to know more about the book.

The popular e-book reader [readmill.com](https://readmill.com/) did not support the book because of the missing metadata information.

According to what people write in the comments for issue #71, it should also fix the problem of the mobi showing up with the title "Unknown" and author "Unknown" on Amazon Kindle.
