### PR TITLE
Fix pandoc 1.15 erroring with \tightlist

### DIFF
--- a/src/convert_to_tex.sh
+++ b/src/convert_to_tex.sh
@@ -32,6 +32,8 @@ cat > $DIR/main.tex <<EOF
 \usepackage{tocloft}
 \usepackage{upquote}
 
+\def\tightlist{}
+
 \let\stdsection\section
 \renewcommand*{\section}{\FloatBarrier\stdsection}
 \let\stdsubsection\subsection
@@ -60,7 +62,7 @@ for d in chapter*; do
 	echo "\\graphicspath{{./$d/}}" >> $DIR/main.tex
 	title=`echo $d | sed 's/chapter_[0-9][0-9]_//; s/_/ /g; s/^./\U&/; s/ ./\U&/g'`
 	echo "\\chapter{$title}" >> $DIR/main.tex
-	for f in $d/*.md; do 
+	for f in $d/*.md; do
 		pandoc -f markdown -t latex $f -o $DIR/$f.tex
 		echo "\\input{$f.tex}" >> $DIR/main.tex
 	done


### PR DESCRIPTION
Patches the issue I reported, #117 -- but the "ideal" solution is probably to use [pandoc's default template](https://raw.githubusercontent.com/jgm/pandoc-templates/master/default.latex). I'm not sure how that would effect the handbook across different versions of pandoc, and if its inclusion would in fact mess up parts that already work. We may have to patch the .tex file by hand as it tries to introduce its own commands.